### PR TITLE
Crossfilter (for barplots)

### DIFF
--- a/dashdo-examples/src/StatView.hs
+++ b/dashdo-examples/src/StatView.hs
@@ -96,11 +96,13 @@ process ctl (ps, us) = do
   let user = map (fromIntegral . userID) $ filter ((== _processUser ctl) . pack . userName) us
       userFilter (uid:_) = ((== uid) . procUid)
       userFilter _ = const True
+
       processes = hbarChart . map (decodeUtf8 . procName &&& procCPUPercent)
         $ filter (_tagVal $ _processFilter ctl) $ filter (userFilter user) ps
-      userCPU u = let uid = fromIntegral (userID u)
-        in sum . map procCPUPercent . filter ((== uid) . procUid) $ ps
-      users = hbarChart . filter ((> 0) . snd) $ map (pack . userName &&& userCPU) us
+      
+      users = hbarChart . filter ((> 0) . snd) $ map (pack . userName &&& userCPU) us where
+        userCPU u = sum . map procCPUPercent . filter ((== uid) . procUid) $ ps where
+          uid = fromIntegral (userID u)
 
   controls $
     checkbox "Hide inactive processes" psActive psAll processFilter

--- a/dashdo-examples/src/StatView.hs
+++ b/dashdo-examples/src/StatView.hs
@@ -117,7 +117,7 @@ process ctl (ps, us) = do
 
   charts
      [ ("CPU Usage by Process", toHtml $ plotly "ps" [processes] & layout . margin ?~ thinMargins)
-     , ("CPU Usage by User",    plotlySelect (plotly "us" [users] & layout . margin ?~ thinMargins) "y" processUser)]
+     , ("CPU Usage by User",    plotlySelect (plotly "us" [users] & layout . margin ?~ thinMargins) processUser)]
 
 -- end of Processes dashdo
 

--- a/dashdo-examples/src/StatView.hs
+++ b/dashdo-examples/src/StatView.hs
@@ -96,13 +96,13 @@ psDashdo = Dashdo (PsCtl All "") (const getStats) process
 process :: PsCtl -> ([Process], [UserEntry]) -> SHtml PsCtl ()
 process ctl (ps, us) = do
   -- TODO: multiple dimensions...
-  let user = (fromIntegral . userID) <$> filter ((== _processUser ctl) . pack . userName) us
+  let user = (fromIntegral . userID) <$> filter ((== ctl ^. processUser) . pack . userName) us
       userFilter (uid:_) = ((== uid) . procUid)
       userFilter _ = const True  -- empty user filter
 
       processes = hbarChart 
         $ map (decodeUtf8 . procName &&& procCPUPercent)
-        $ filter (filterProcesses $ _processFilterType ctl) 
+        $ filter (filterProcesses $ ctl ^. processFilterType) 
         $ filter (userFilter user) ps
       
       users = hbarChart 

--- a/dashdo-examples/src/StatView.hs
+++ b/dashdo-examples/src/StatView.hs
@@ -96,7 +96,6 @@ psDashdo = Dashdo (PsCtl All []) (const getStats) process
 
 process :: PsCtl -> ([Process], [UserEntry]) -> SHtml PsCtl ()
 process ctl (ps, us) = do
-  -- TODO: multiple dimensions...
   let userFilter = case L.filter ((`elem` ctl ^. processUsers) . pack . userName) us of
         []  -> const True
         lst -> (`elem` ((fromIntegral . userID) <$> lst)) . procUid

--- a/dashdo-examples/src/StatView.hs
+++ b/dashdo-examples/src/StatView.hs
@@ -98,7 +98,8 @@ process ctl (ps, us) = do
       userFilter _ = const True
 
       processes = hbarChart . map (decodeUtf8 . procName &&& procCPUPercent)
-        $ filter (_tagVal $ _processFilter ctl) $ filter (userFilter user) ps
+        $ filter (_tagVal $ _processFilter ctl) 
+        $ filter (userFilter user) ps
       
       users = hbarChart . filter ((> 0) . snd) $ map (pack . userName &&& userCPU) us where
         userCPU u = sum . map procCPUPercent . filter ((== uid) . procUid) $ ps where

--- a/dashdo-examples/src/StatView.hs
+++ b/dashdo-examples/src/StatView.hs
@@ -93,17 +93,20 @@ psDashdo = Dashdo (PsCtl psAll "") (const getStats) process
 
 process :: PsCtl -> ([Process], [UserEntry]) -> SHtml PsCtl ()
 process ctl (ps, us) = do
-  let user = map (fromIntegral . userID) $ filter ((== _processUser ctl) . pack . userName) us
+  let user = (fromIntegral . userID) <$> filter ((== _processUser ctl) . pack . userName) us
       userFilter (uid:_) = ((== uid) . procUid)
-      userFilter _ = const True
+      userFilter _ = const True  -- empty user filter
 
-      processes = hbarChart . map (decodeUtf8 . procName &&& procCPUPercent)
+      processes = hbarChart 
+        $ map (decodeUtf8 . procName &&& procCPUPercent)
         $ filter (_tagVal $ _processFilter ctl) 
         $ filter (userFilter user) ps
       
-      users = hbarChart . filter ((> 0) . snd) $ map (pack . userName &&& userCPU) us where
-        userCPU u = sum . map procCPUPercent . filter ((== uid) . procUid) $ ps where
-          uid = fromIntegral (userID u)
+      users = hbarChart 
+        $ filter ((> 0) . snd) 
+        $ map (pack . userName &&& userCPU) us where
+          userCPU u = sum . map procCPUPercent . filter ((== uid) . procUid) $ ps where
+            uid = fromIntegral (userID u)
 
   controls $
     checkbox "Hide inactive processes" psActive psAll processFilter

--- a/dashdo-examples/stack.yaml
+++ b/dashdo-examples/stack.yaml
@@ -41,6 +41,7 @@ packages:
 - '../../open/dashdo/'
 - '../../open/lucid-extras/'
 - '../../open/fuml/'
+- '../../open/datasets'
 
 #- location:
 #    git: git@github.com:glutamate/plotlyhs

--- a/dashdo/public/js/dashdo.js
+++ b/dashdo/public/js/dashdo.js
@@ -23,7 +23,7 @@
       var settings = $.extend({
         // These are the defaults.
         ajax: false,
-        uuidUrl: "/uuid",
+        uuidUrl: '/uuid',
         uuidInterval: 1000,
 
         colorSelected: '#1F77B4',
@@ -41,20 +41,20 @@
       }, options)
 
       var resubmitNatively = function() {
-        $("input", this).prop('readonly', true);
+        $('input', this).prop('readonly', true)
         $(this).submit()
       }.bind(this)
 
-      $(this).on("change", ":input", function() {
-        if (typeof(manual_submit) === "undefined" || !manual_submit) {
-          $(":input").prop("readonly", true);
+      $(this).on('change', ':input', function() {
+        if (typeof(manual_submit) === 'undefined' || !manual_submit) {
+          $(':input').prop('readonly', true)
           properReSubmit()
         }
       })
 
-      this.filter("form").on("submit", function(e) {
+      this.filter('form').on('submit', function(e) {
         if(!settings.ajax) {
-          $("input", this).prop('readonly', true);
+          $('input', this).prop('readonly', true)
           return // and then it actualy submits
         }
         e.preventDefault()  // no 'native' submitting on ajax versions
@@ -62,7 +62,7 @@
 
       var requestHtmlFromServer = function(url, data, onSuccess) {
         $.ajax({
-          type: "POST",
+          type: 'POST',
           url: url,
           data: data,
           success: onSuccess,
@@ -72,14 +72,14 @@
       var resubmitWithAjax = function(onSuccessfulRender) {
         if(!!settings.containerElement) {
           requestHtmlFromServer(
-            $(this).attr("action"),
+            $(this).attr('action'),
             $(this).serialize(),
             function(data) {
               $(settings.containerElement).html(data)
               
               $('.dashdo-plotly-select .js-plotly-plot').each(function() {
-                var graph = $(this).get(0);
-                var axis = (graph.data[0].orientation === "h") ? "y" : "x";
+                var graph = $(this).get(0)
+                var axis = (graph.data[0].orientation === 'h') ? 'y' : 'x'
 
                 var values = $(this).siblings('input[name]').map(function() {  // name must be specified!
                   return this.value
@@ -89,17 +89,17 @@
                   if (values.length === 0) {
                     // making all graph selected
                     console.log('all are selected! ^))')
-                    Plotly.restyle(graph, { 'marker.color': settings.colorSelected });
+                    Plotly.restyle(graph, { 'marker.color': settings.colorSelected })
                   } else {
                     var os = graph.data[0][axis].map(function(p) {  // example: graph.data[0]['y']
                       return (values.indexOf(p) !== -1) ? // p `elem` values == True
                         settings.colorSelected : 
-                        settings.colorUnSelected;
-                    });
-                    Plotly.restyle(graph, {'marker.color' : [os]}, [0]);
+                        settings.colorUnSelected
+                    })
+                    Plotly.restyle(graph, {'marker.color' : [os]}, [0])
                   }
-                };
-                restyle();
+                }
+                restyle()
 
                 var currentMultipleFieldName = $(this).siblings(settings.multiselectNamesSelector).val()
                 var isMultiple = !!currentMultipleFieldName
@@ -110,9 +110,9 @@
                   if(!isMultiple) {
                     var input = $(this).siblings('input[name]').first()
                     if (input.attr('value') == selectedValueFromPlot) { // if selected
-                      input.attr('value', ''); // then deselect
+                      input.attr('value', '') // then deselect
                     } else {
-                      input.attr('value', selectedValueFromPlot);  // if not selected, then select
+                      input.attr('value', selectedValueFromPlot)  // if not selected, then select
                     }
                   } else {
                     var currentInputs = $(this).siblings('input[name="' + currentMultipleFieldName + '"][value="' + selectedValueFromPlot + '"]')
@@ -125,8 +125,8 @@
                   }
 
                   properReSubmit()
-                }.bind(this));
-              });
+                }.bind(this))
+              })
 
               // if switched & rendered successfully, renew periodic submit loop
               clearInterval(submitTimer)
@@ -138,7 +138,7 @@
 
       var properReSubmit = (settings.ajax) ?
             resubmitWithAjax :
-            resubmitNatively;
+            resubmitNatively
 
       var uuid = null
       var uuidLoop = function() {
@@ -177,7 +177,7 @@
       }
 
       var switchDashdo = function(endpoint) {
-        $(this).attr("action", endpoint)  // set action of the form to the endpoint
+        $(this).attr('action', endpoint)  // set action of the form to the endpoint
         refreshTitle(endpoint)
         resubmitWithAjax()
       }.bind(this)
@@ -198,7 +198,7 @@
         }
       }
 
-      return this; // returning the dashdo
+      return this // returning the dashdo
     }
  
-}( jQuery ));
+}( jQuery ))

--- a/dashdo/public/js/dashdo.js
+++ b/dashdo/public/js/dashdo.js
@@ -78,9 +78,11 @@
                 var _restyle = function() {
                   var value = input.attr('value');
                   if (value === "") {
+                    // making all graph unselected
                     Plotly.restyle(graph, { 'marker.color': '#1F77B4' });
                   } else {
                     var os = graph.data[0][attr].map(function(p) {  // example: graph.data[0]['y']
+                      // TODO: p `elem` [values]
                       return p == value ? '#1F77B4' : '#A5C8E1';
                     });
                     Plotly.restyle(graph, {'marker.color' : [os]}, [0]);
@@ -88,10 +90,14 @@
                 };
                 _restyle();
 
+                // TODO: separate function for multiple
                 $(this).get(0).on('plotly_click', function(data) {
                   if (input.attr('value') == data.points[0][attr]) {
+                    // unchecking currently selected
+                    // TODO: remove from [values]
                     input.attr('value', "");
                   } else {
+                    // TODO: add to [values]
                     input.attr('value', data.points[0][attr]);
                   }
                   _restyle()

--- a/dashdo/public/js/dashdo.js
+++ b/dashdo/public/js/dashdo.js
@@ -78,7 +78,7 @@
                 var _restyle = function() {
                   var value = input.attr('value');
                   if (value === "") {
-                    Plotly.restyle(graph, { 'marker.color': '#1F77B4)' });
+                    Plotly.restyle(graph, { 'marker.color': '#1F77B4' });
                   } else {
                     var os = graph.data[0][attr].map(function(p) {  // example: graph.data[0]['y']
                       return p == value ? '#1F77B4' : '#A5C8E1';

--- a/dashdo/public/js/dashdo.js
+++ b/dashdo/public/js/dashdo.js
@@ -73,34 +73,38 @@
               $('.dashdo-plotly-select .js-plotly-plot').each(function() {
                 var graph = $(this).get(0);
                 var axis = (graph.data[0].orientation === "h") ? "y" : "x";
-                var input = $(this).siblings('input').first();
 
-                var _restyle = function() {
-                  var value = input.attr('value');
-                  if (value === "") {
+                var firstInputName = $(this).siblings('input').first().attr('name')
+                if (!firstInputName) return // falsey value - input with 'name' attr is not found
+
+                var values = $(this).siblings('input').map(function() {
+                  return this.value
+                }).get()
+                
+                var restyle = function() {
+                  if (values.length === 0) {
                     // making all graph unselected
                     Plotly.restyle(graph, { 'marker.color': '#1F77B4' });
                   } else {
                     var os = graph.data[0][axis].map(function(p) {  // example: graph.data[0]['y']
-                      // TODO: p `elem` [values]
-                      return p == value ? '#1F77B4' : '#A5C8E1';
+                      return (values.indexOf(p) !== -1) ? '#1F77B4' : '#A5C8E1';
                     });
                     Plotly.restyle(graph, {'marker.color' : [os]}, [0]);
                   }
                 };
-                _restyle();
+                restyle();
 
-                // TODO: separate function for multiple
+                var input = $(this).siblings('input').first();                
                 $(this).get(0).on('plotly_click', function(data) {
                   if (input.attr('value') == data.points[0][axis]) {
-                    // unchecking currently selected
-                    // TODO: remove from [values]
-                    input.attr('value', "");
+                    // TODO: what if someone wants _not_ multiselectable plotly?
+                    // TODO: remove item's input
+                    // input.attr('value', '');
                   } else {
-                    // TODO: add to [values]
-                    input.attr('value', data.points[0][axis]);
+                    // TODO: add input corresponding to current item
+                    // input.attr('value', data.points[0][axis]);
                   }
-                  _restyle()
+                  restyle()
                   input.change()
                 });
               });

--- a/dashdo/public/js/dashdo.js
+++ b/dashdo/public/js/dashdo.js
@@ -95,7 +95,7 @@
                     input.attr('value', data.points[0][attr]);
                   }
                   _restyle()
-                  input.change()  // to fix: input.change causes resubmit that 'looses' .dashdo-plotly-select events
+                  input.change()
                 });
               });
 

--- a/dashdo/public/js/dashdo.js
+++ b/dashdo/public/js/dashdo.js
@@ -72,7 +72,7 @@
               
               $('.dashdo-plotly-select .js-plotly-plot').each(function() {
                 var graph = $(this).get(0);
-                var attr = $(this).siblings('.dashdo-plotly-select-attr').attr('value');
+                var axis = (graph.data[0].orientation === "h") ? "y" : "x";
                 var input = $(this).siblings('input').first();
 
                 var _restyle = function() {
@@ -81,7 +81,7 @@
                     // making all graph unselected
                     Plotly.restyle(graph, { 'marker.color': '#1F77B4' });
                   } else {
-                    var os = graph.data[0][attr].map(function(p) {  // example: graph.data[0]['y']
+                    var os = graph.data[0][axis].map(function(p) {  // example: graph.data[0]['y']
                       // TODO: p `elem` [values]
                       return p == value ? '#1F77B4' : '#A5C8E1';
                     });
@@ -92,13 +92,13 @@
 
                 // TODO: separate function for multiple
                 $(this).get(0).on('plotly_click', function(data) {
-                  if (input.attr('value') == data.points[0][attr]) {
+                  if (input.attr('value') == data.points[0][axis]) {
                     // unchecking currently selected
                     // TODO: remove from [values]
                     input.attr('value', "");
                   } else {
                     // TODO: add to [values]
-                    input.attr('value', data.points[0][attr]);
+                    input.attr('value', data.points[0][axis]);
                   }
                   _restyle()
                   input.change()

--- a/dashdo/src/Dashdo.hs
+++ b/dashdo/src/Dashdo.hs
@@ -18,9 +18,11 @@ dashdoGenOut (Dashdo _ f r) x = do
 
 parseForm :: a -> FormFields a -> [(TL.Text, TL.Text)] -> a
 parseForm x [] _ = x
-parseForm x ((n,f):nfs) pars =
-  let fldName = "f"<>TL.pack (show n)
-      newx = case lookup fldName pars of
-               Nothing -> x
-               Just lt -> f x (TL.toStrict lt)
+parseForm x ((n,f):nfs) pars =                  -- x=initial d (accumulator)
+  let fldName = "f"<>TL.pack (show n)           -- fn
+      newx = case lookup fldName pars of        -- looking for fn in params [(TL.Text, TL.Text)]
+               Just lt -> f x (TL.toStrict lt)  -- apply function corresponding to `n` in list of FormFields - number-function pairs
+               Nothing -> case filter ((== fldName <> "[]") . fst) pars of -- if nothing found, try looking for fn[]
+                 [] -> x
+                 listParams -> foldl f x (map (TL.toStrict . snd) listParams)
   in parseForm newx nfs pars

--- a/dashdo/src/Dashdo/Elements.hs
+++ b/dashdo/src/Dashdo/Elements.hs
@@ -116,5 +116,14 @@ plotlySelect plot f = do
   (val, n) <- freshAndValue
   putFormField (n, lensSetter f)
   div_ [class_ "dashdo-plotly-select"] $ do
-    toHtml plot  -- abstract, cool
-    input_ [type_ "hidden", fieldName n, value_ (val ^. f)]  -- TODO: for_; multiple values -- fn[] (in separate plotlySelectMultiple function)
+    toHtml plot
+    input_ [type_ "hidden", fieldName n, value_ (val ^. f)]
+
+plotlySelectMultiple :: Plotly -> Lens' a [Text] -> SHtml a ()
+plotlySelectMultiple plot f = do
+  (val, n) <- freshAndValue
+  putFormField (n, lensPusher f)
+  div_ [class_ "dashdo-plotly-select"] $ do
+    toHtml plot
+    forM_ (val ^. f) $ \(v) ->
+      input_ [type_ "hidden", fieldNameMultiple n, value_ v]

--- a/dashdo/src/Dashdo/Elements.hs
+++ b/dashdo/src/Dashdo/Elements.hs
@@ -125,5 +125,6 @@ plotlySelectMultiple plot f = do
   putFormField (n, lensPusher f)
   div_ [class_ "dashdo-plotly-select"] $ do
     toHtml plot
+    input_ [type_ "hidden", class_ "dashdo-plotly-multi-select-names", value_ $ mkFieldNameMultiple n]
     forM_ (val ^. f) $ \(v) ->
       input_ [type_ "hidden", fieldNameMultiple n, value_ v]

--- a/dashdo/src/Dashdo/Elements.hs
+++ b/dashdo/src/Dashdo/Elements.hs
@@ -111,11 +111,10 @@ checkbox text vTrue vFalse f = do
   -- if checkbox doesn't supply a value we get this one instead
   input_ [type_ "hidden", fieldName n, value_ "false"]
 
-plotlySelect :: Plotly -> Text -> Lens' a Text -> SHtml a ()
-plotlySelect plot attr f = do
+plotlySelect :: Plotly -> Lens' a Text -> SHtml a ()
+plotlySelect plot f = do
   (val, n) <- freshAndValue
   putFormField (n, lensSetter f)
   div_ [class_ "dashdo-plotly-select"] $ do
-    toHtml plot
-    input_ [type_ "hidden", fieldName n, value_ (val ^. f)]
-    input_ [type_ "hidden", class_ "dashdo-plotly-select-attr", value_ attr]
+    toHtml plot  -- abstract, cool
+    input_ [type_ "hidden", fieldName n, value_ (val ^. f)]  -- TODO: for_; multiple values -- fn[] (in separate plotlySelectMultiple function)

--- a/dashdo/src/Dashdo/Types.hs
+++ b/dashdo/src/Dashdo/Types.hs
@@ -30,11 +30,17 @@ runSHtml val shtml =
       (t, (_, _, ffs)) = runState stT (0, val, [])
   in (ffs, t)
 
+mkFieldName :: Int -> Text
+mkFieldName = ((<>) "f") . pack . show
+
+mkFieldNameMultiple :: Int -> Text
+mkFieldNameMultiple n = mkFieldName n <> "[]"
+
 fieldName :: Int -> Attribute
-fieldName n = name_ $ "f"<>pack (show n)
+fieldName = name_ . mkFieldName
 
 fieldNameMultiple :: Int -> Attribute
-fieldNameMultiple n = name_ $ "f" <>pack (show n) <> "[]"
+fieldNameMultiple = name_ . mkFieldNameMultiple
 
 fresh :: SHtml a Int
 fresh = do

--- a/dashdo/src/Dashdo/Types.hs
+++ b/dashdo/src/Dashdo/Types.hs
@@ -33,6 +33,9 @@ runSHtml val shtml =
 fieldName :: Int -> Attribute
 fieldName n = name_ $ "f"<>pack (show n)
 
+fieldNameMultiple :: Int -> Attribute
+fieldNameMultiple n = name_ $ "f" <>pack (show n) <> "[]"
+
 fresh :: SHtml a Int
 fresh = do
   (n, v, ffs) <- lift $ get
@@ -53,3 +56,6 @@ putFormField ff = do
 
 lensSetter :: ASetter' s a -> (s -> a -> s)
 lensSetter l x y = x & l .~ y
+
+lensPusher :: ASetter s t [a] [a] -> s -> a -> t
+lensPusher l x y = over l ((:) y) x


### PR DESCRIPTION
Crossfiltering functionality for barplots

 - `plotlySelectMultiple` function (an analogue of `plotlySelect`)
 - `parseForm` undersnands multiple parameters like `name="f0[]"`
 - simplified StatView.hs
 - removed axis parameter (`"y"`) from `plotlySelect`
 - (a bug?): "../../open/datasets" was not mentioned in dashdo-examples/stack.yaml
 - little cosmetics in js: single style for using semicolons (no semicolons) and quotes