### PR TITLE
Crossfiltering v2

### DIFF
--- a/dashdo-examples/dashdo-examples.cabal
+++ b/dashdo-examples/dashdo-examples.cabal
@@ -59,3 +59,17 @@ executable statview-dashdo
                      , statgrab
                      , lucid-extras
                      , unix
+
+executable gapminder-dashdo
+  main-is: GapminderScatterplot.hs
+  default-language:  Haskell2010
+  hs-source-dirs:    src
+  build-depends:       base >=4.6 && <5
+                     , plotlyhs
+                     , datasets
+                     , lucid
+                     , aeson
+                     , text
+                     , dashdo
+                     , microlens-platform
+                     , lucid-extras

--- a/dashdo-examples/src/GapminderScatterplot.hs
+++ b/dashdo-examples/src/GapminderScatterplot.hs
@@ -73,6 +73,7 @@ countriesScatterPlot gms =
       scatter
         & B.x ?~ (toJSON . gdpPercap <$> gms)
         & B.y ?~ (toJSON . lifeExp <$> gms)
+        & B.customdata ?~ (toJSON . country <$> gms)
         & B.mode ?~ [B.Markers]
         & B.text ?~ (country <$> gms)
         & B.marker ?~ 
@@ -118,12 +119,12 @@ continentsGDPsPie gms =
 
     trace :: Trace
     trace = pie
-      & labels .~ Just pieLabels
-      & values .~ Just pieValues
-      & hole .~ Just (toJSON 0.4)
-      & marker .~ (Just $
-        defMarker
-          & markercolors .~ Just pieColors)
+      & labels ?~ pieLabels
+      & values ?~ pieValues
+      & customdata ?~ (toJSON <$> pieLabels)
+      & hole ?~ (toJSON 0.4)
+      & marker ?~ (defMarker
+        & markercolors .~ Just pieColors)
 
   in toHtml $ 
     plotly "continents-gdp" [trace]

--- a/dashdo-examples/src/GapminderScatterplot.hs
+++ b/dashdo-examples/src/GapminderScatterplot.hs
@@ -13,6 +13,7 @@ import Lucid.Bootstrap3
 import Data.Monoid ((<>))
 import qualified Data.Foldable as DF
 import Data.Text (Text, unpack, pack)
+import Data.Aeson.Types
 import Lens.Micro.Platform
 import Control.Monad
 
@@ -66,12 +67,19 @@ countriesScatterPlot gms =
     trace = points (aes & x .~ gdpPercap
                         & y .~ lifeExp
                         & color .~ Just (continentRGB . read . unpack . continent)) gms
+    xTicks = [
+        (1000,  "$ 1,000")
+      , (10000, "$ 10,000")
+      , (50000, "$ 50,000")]
+
   in toHtml $
     plotly "countries-scatterplot" [trace]
       & layout %~ xaxis .~ (Just $ 
         defAxis 
           & axistype  .~ Just Log
-          & axistitle .~ Just "GDP Per Capita")
+          & axistitle .~ Just "GDP Per Capita"
+          & tickvals .~ Just (map (toJSON . fst) xTicks)
+          & ticktext .~ Just (map (pack . snd) xTicks))
       & layout %~ yaxis .~ (Just $ defAxis & axistitle .~ Just "Life Expectancy")
 
 gmRenderer :: [Gapminder] -> GmParams -> () -> SHtml GmParams ()

--- a/dashdo-examples/src/GapminderScatterplot.hs
+++ b/dashdo-examples/src/GapminderScatterplot.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE OverloadedStrings, ExistentialQuantification, ExtendedDefaultRules, FlexibleContexts, TemplateHaskell #-}
+
+import Numeric.Datasets
+import Numeric.Datasets.Gapminder
+
+import Dashdo
+import Dashdo.Types
+import Dashdo.Serve
+import Dashdo.Elements
+import Lucid
+import Lucid.Bootstrap
+import Lucid.Bootstrap3
+import Data.Monoid ((<>))
+import Data.Text (Text, unpack, pack)
+import Lens.Micro.Platform
+import Control.Monad
+
+import Graphics.Plotly hiding (xaxis, yaxis)
+import Graphics.Plotly.Lucid
+
+data GmParams = GmParams
+ {
+   _selCountries :: [Text]
+ , _selRegions  :: [Text]
+ }
+
+makeLenses ''GmParams
+
+gm0 = GmParams [] []
+
+gmRenderer :: [Gapminder] -> GmParams -> () ->  SHtml GmParams ()
+gmRenderer gms gmParams () =
+  wrap plotlyCDN $ do
+    h1_ "Gapminder scatterplot example"
+    row_ $ do
+      mkCol [(MD,12)] $ do
+        table_ [class_ "table table-striped"] $ do
+          thead_ $ do
+            tr_ $ do
+              th_ "Country"
+              th_ "Year"
+              th_ "Population"
+              th_ "Gdp per capita"
+              th_ "Life expectancy"
+          {-
+          tbody_ $ do
+            for_ gms $ \(c) -> do
+              tr_ $ do
+                td_ $ country   c
+                td_ $ year      c
+                td_ $ pop       c
+                td_ $ gdpPercap c
+                td_ $ lifeExp   c
+          -}
+
+main = do
+  gms <- getDataset gapminder
+  runDashdo $ Dashdo gm0 (return . const ()) (gmRenderer gms)

--- a/dashdo-examples/src/GapminderScatterplot.hs
+++ b/dashdo-examples/src/GapminderScatterplot.hs
@@ -11,6 +11,7 @@ import Lucid
 import Lucid.Bootstrap
 import Lucid.Bootstrap3
 import Data.Monoid ((<>))
+import qualified Data.Foldable as DF
 import Data.Text (Text, unpack, pack)
 import Lens.Micro.Platform
 import Control.Monad
@@ -42,16 +43,15 @@ gmRenderer gms gmParams () =
               th_ "Population"
               th_ "Gdp per capita"
               th_ "Life expectancy"
-          {-
+          
           tbody_ $ do
-            for_ gms $ \(c) -> do
+            DF.for_ gms $ \(c) -> do
               tr_ $ do
-                td_ $ country   c
-                td_ $ year      c
-                td_ $ pop       c
-                td_ $ gdpPercap c
-                td_ $ lifeExp   c
-          -}
+                td_ $ toHtml (country          c)
+                td_ $ toHtml (show $ year      c)
+                td_ $ toHtml (show $ pop       c)
+                td_ $ toHtml (show $ gdpPercap c)
+                td_ $ toHtml (show $ lifeExp   c)
 
 main = do
   gms <- getDataset gapminder

--- a/dashdo-examples/src/GapminderScatterplot.hs
+++ b/dashdo-examples/src/GapminderScatterplot.hs
@@ -16,7 +16,7 @@ import Data.Text (Text, unpack, pack)
 import Lens.Micro.Platform
 import Control.Monad
 
-import Graphics.Plotly hiding (xaxis, yaxis)
+import Graphics.Plotly
 import Graphics.Plotly.Lucid
 
 data GmParams = GmParams
@@ -66,7 +66,10 @@ countriesScatterPlot gms =
     trace = points (aes & x .~ gdpPercap
                         & y .~ lifeExp
                         & color .~ Just (continentRGB . read . unpack . continent)) gms
-  in toHtml $ plotly "scatterplot" [trace]
+  in toHtml $
+    plotly "countries-scatterplot" [trace]
+      & layout %~ xaxis .~ (Just $ defAxis & axistitle .~ Just "GDP Per Capita")
+      & layout %~ yaxis .~ (Just $ defAxis & axistitle .~ Just "Life Expectancy")
 
 gmRenderer :: [Gapminder] -> GmParams -> () -> SHtml GmParams ()
 gmRenderer gms gmParams () =

--- a/dashdo-examples/src/GapminderScatterplot.hs
+++ b/dashdo-examples/src/GapminderScatterplot.hs
@@ -68,7 +68,10 @@ countriesScatterPlot gms =
                         & color .~ Just (continentRGB . read . unpack . continent)) gms
   in toHtml $
     plotly "countries-scatterplot" [trace]
-      & layout %~ xaxis .~ (Just $ defAxis & axistitle .~ Just "GDP Per Capita")
+      & layout %~ xaxis .~ (Just $ 
+        defAxis 
+          & axistype  .~ Just Log
+          & axistitle .~ Just "GDP Per Capita")
       & layout %~ yaxis .~ (Just $ defAxis & axistitle .~ Just "Life Expectancy")
 
 gmRenderer :: [Gapminder] -> GmParams -> () -> SHtml GmParams ()

--- a/dashdo-examples/src/GapminderScatterplot.hs
+++ b/dashdo-examples/src/GapminderScatterplot.hs
@@ -74,6 +74,7 @@ countriesScatterPlot gms =
         & B.x ?~ (toJSON . gdpPercap <$> gms)
         & B.y ?~ (toJSON . lifeExp <$> gms)
         & B.mode ?~ [B.Markers]
+        & B.text ?~ (country <$> gms)
         & B.marker ?~ 
           (defMarker
             & B.markercolor ?~ (List $ toJSON . continentRGB . read . unpack . continent <$> gms)

--- a/dashdo-examples/src/GapminderScatterplot.hs
+++ b/dashdo-examples/src/GapminderScatterplot.hs
@@ -29,13 +29,25 @@ makeLenses ''GmParams
 
 gm0 = GmParams [] []
 
+data Continent = Africa | Americas | Asia | Europe | Oceania deriving (Eq, Show, Read)
+
+continentRGB :: Continent -> RGB Int
+continentRGB Africa   = RGB 255 165 0
+continentRGB Americas = RGB 255 0 0
+continentRGB Asia     = RGB 128 0 128
+continentRGB Europe   = RGB 0 255 0
+continentRGB Oceania  = RGB 0 0 255
+continentRGB _ = undefined
+
+-- TODO: 1 - doghunt 2- sum gdp for region
+-- TODO: plotlySelectMultiple
+
 countriesTable :: [Gapminder] -> SHtml GmParams ()
 countriesTable gms =
   table_ [class_ "table table-striped"] $ do
     thead_ $ do
       tr_ $ do
         th_ "Country"
-        th_ "Year"
         th_ "Population"
         th_ "Gdp per capita"
         th_ "Life expectancy"
@@ -43,19 +55,32 @@ countriesTable gms =
       DF.for_ gms $ \(c) -> do
         tr_ $ do
           td_ $ toHtml (country          c)
-          td_ $ toHtml (show $ year      c)
           td_ $ toHtml (show $ pop       c)
           td_ $ toHtml (show $ gdpPercap c)
           td_ $ toHtml (show $ lifeExp   c)
+
+countriesScatterPlot :: [Gapminder] -> SHtml GmParams ()
+countriesScatterPlot gms =
+  let
+    trace :: Trace
+    trace = points (aes & x .~ gdpPercap
+                        & y .~ lifeExp
+                        & color .~ Just (continentRGB . read . unpack . continent)) gms
+  in toHtml $ plotly "scatterplot" [trace]
 
 gmRenderer :: [Gapminder] -> GmParams -> () -> SHtml GmParams ()
 gmRenderer gms gmParams () =
   wrap plotlyCDN $ do
     h1_ "Gapminder scatterplot example"
     row_ $ do
+      mkCol [(MD,8)] $ do
+        countriesScatterPlot gms
+      mkCol [(MD,4)] $ do
+        "Doghunt chart goes here"
+    row_ $ do
       mkCol [(MD,12)] $ do
         countriesTable gms
 
 main = do
   gms <- getDataset gapminder
-  runDashdo $ Dashdo gm0 (return . const ()) (gmRenderer gms)
+  runDashdo $ Dashdo gm0 (return . const ()) (gmRenderer $ filter ((== 2007) . year) gms)

--- a/dashdo-examples/src/GapminderScatterplot.hs
+++ b/dashdo-examples/src/GapminderScatterplot.hs
@@ -35,7 +35,7 @@ continentRGB :: Continent -> RGB Int
 continentRGB Africa   = RGB 255 165 0
 continentRGB Americas = RGB 255 0 0
 continentRGB Asia     = RGB 128 0 128
-continentRGB Europe   = RGB 0 255 0
+continentRGB Europe   = RGB 0 128 0
 continentRGB Oceania  = RGB 0 0 255
 continentRGB _ = undefined
 

--- a/dashdo-examples/src/GapminderScatterplot.hs
+++ b/dashdo-examples/src/GapminderScatterplot.hs
@@ -29,29 +29,32 @@ makeLenses ''GmParams
 
 gm0 = GmParams [] []
 
-gmRenderer :: [Gapminder] -> GmParams -> () ->  SHtml GmParams ()
+countriesTable :: [Gapminder] -> SHtml GmParams ()
+countriesTable gms =
+  table_ [class_ "table table-striped"] $ do
+    thead_ $ do
+      tr_ $ do
+        th_ "Country"
+        th_ "Year"
+        th_ "Population"
+        th_ "Gdp per capita"
+        th_ "Life expectancy"
+    tbody_ $ do
+      DF.for_ gms $ \(c) -> do
+        tr_ $ do
+          td_ $ toHtml (country          c)
+          td_ $ toHtml (show $ year      c)
+          td_ $ toHtml (show $ pop       c)
+          td_ $ toHtml (show $ gdpPercap c)
+          td_ $ toHtml (show $ lifeExp   c)
+
+gmRenderer :: [Gapminder] -> GmParams -> () -> SHtml GmParams ()
 gmRenderer gms gmParams () =
   wrap plotlyCDN $ do
     h1_ "Gapminder scatterplot example"
     row_ $ do
       mkCol [(MD,12)] $ do
-        table_ [class_ "table table-striped"] $ do
-          thead_ $ do
-            tr_ $ do
-              th_ "Country"
-              th_ "Year"
-              th_ "Population"
-              th_ "Gdp per capita"
-              th_ "Life expectancy"
-          
-          tbody_ $ do
-            DF.for_ gms $ \(c) -> do
-              tr_ $ do
-                td_ $ toHtml (country          c)
-                td_ $ toHtml (show $ year      c)
-                td_ $ toHtml (show $ pop       c)
-                td_ $ toHtml (show $ gdpPercap c)
-                td_ $ toHtml (show $ lifeExp   c)
+        countriesTable gms
 
 main = do
   gms <- getDataset gapminder

--- a/dashdo/public/js/dashdo.js
+++ b/dashdo/public/js/dashdo.js
@@ -39,6 +39,7 @@
       dashdoTitleSelector: '#dashdo-title',
 
       multiselectNamesSelector: '.dashdo-plotly-multi-select-names',
+      resetLinkSelector: '.dashdo-resetlink',
     }, options)
 
     var resubmitNatively = function() {
@@ -68,6 +69,15 @@
       }
       e.preventDefault()  // no 'native' submitting on ajax versions
     })
+
+    if(!!settings.resetLinkSelector) {
+      $(settings.resetLinkSelector).each(function() {
+        $(this).on('click', function() {
+          $(this).siblings('input[name]').remove()
+          properReSubmit()
+        })
+      })
+    }
 
     var requestHtmlFromServer = function(url, data, onSuccess) {
       $.ajax({

--- a/dashdo/public/js/dashdo.js
+++ b/dashdo/public/js/dashdo.js
@@ -1,204 +1,204 @@
 (function ( $ ) {
- 
-    $.fn.dashdo = function(options) {
-      /*
-      options:
 
-       basic:
-        - ajax: true / false (default: false),
-        - uuidUrl (default: '/uuid')
-        - uuidInterval (default: 1000)
-        - periodicSubmitSelector (default: '.dashdo-periodic-submit')
-        - colorSelected: 1F77B4
-        - colorUnSelected: A5C8E1
+  $.fn.dashdo = function(options) {
+    /*
+    options:
 
-       ui (ajax-only!):
-        - dashdoTitleSelector (default: '#dashdo-title')
-        - container (which to (re-)render)
-        - switcherElements: $('.dashdo-link'),
-        - switcherAttr: 'href',
-        - switcherEvent: 'click',
-      */
+      basic:
+      - ajax: true / false (default: false),
+      - uuidUrl (default: '/uuid')
+      - uuidInterval (default: 1000)
+      - periodicSubmitSelector (default: '.dashdo-periodic-submit')
+      - colorSelected: 1F77B4
+      - colorUnSelected: A5C8E1
 
-      var settings = $.extend({
-        // These are the defaults.
-        ajax: false,
-        uuidUrl: '/uuid',
-        uuidInterval: 1000,
+      ui (ajax-only!):
+      - dashdoTitleSelector (default: '#dashdo-title')
+      - container (which to (re-)render)
+      - switcherElements: $('.dashdo-link'),
+      - switcherAttr: 'href',
+      - switcherEvent: 'click',
+    */
 
-        colorSelected: '#1F77B4',
-        colorUnSelected: '#A5C8E1',
-        
-        containerElement: null,
-        switcherElements: null,
-        switcherAttr: 'href',
-        switcherEvent: 'click',
+    var settings = $.extend({
+      // These are the defaults.
+      ajax: false,
+      uuidUrl: '/uuid',
+      uuidInterval: 1000,
 
-        periodicSubmitSelector: '.dashdo-periodic-submit',
-        dashdoTitleSelector: '#dashdo-title',
+      colorSelected: '#1F77B4',
+      colorUnSelected: '#A5C8E1',
+      
+      containerElement: null,
+      switcherElements: null,
+      switcherAttr: 'href',
+      switcherEvent: 'click',
 
-        multiselectNamesSelector: '.dashdo-plotly-multi-select-names',
-      }, options)
+      periodicSubmitSelector: '.dashdo-periodic-submit',
+      dashdoTitleSelector: '#dashdo-title',
 
-      var resubmitNatively = function() {
-        $('input', this).prop('readonly', true)
-        $(this).submit()
-      }.bind(this)
+      multiselectNamesSelector: '.dashdo-plotly-multi-select-names',
+    }, options)
 
-      $(this).on('change', ':input', function() {
-        if (typeof(manual_submit) === 'undefined' || !manual_submit) {
-          $(':input').prop('readonly', true)
-          properReSubmit()
-        }
-      })
+    var resubmitNatively = function() {
+      $('input', this).prop('readonly', true)
+      $(this).submit()
+    }.bind(this)
 
-      this.filter('form').on('submit', function(e) {
-        if(!settings.ajax) {
-          $('input', this).prop('readonly', true)
-          return // and then it actualy submits
-        }
-        e.preventDefault()  // no 'native' submitting on ajax versions
-      })
-
-      var requestHtmlFromServer = function(url, data, onSuccess) {
-        $.ajax({
-          type: 'POST',
-          url: url,
-          data: data,
-          success: onSuccess,
-        })
+    $(this).on('change', ':input', function() {
+      if (typeof(manual_submit) === 'undefined' || !manual_submit) {
+        $(':input').prop('readonly', true)
+        properReSubmit()
       }
+    })
 
-      var resubmitWithAjax = function(onSuccessfulRender) {
-        if(!!settings.containerElement) {
-          requestHtmlFromServer(
-            $(this).attr('action'),
-            $(this).serialize(),
-            function(data) {
-              $(settings.containerElement).html(data)
+    this.filter('form').on('submit', function(e) {
+      if(!settings.ajax) {
+        $('input', this).prop('readonly', true)
+        return // and then it actualy submits
+      }
+      e.preventDefault()  // no 'native' submitting on ajax versions
+    })
+
+    var requestHtmlFromServer = function(url, data, onSuccess) {
+      $.ajax({
+        type: 'POST',
+        url: url,
+        data: data,
+        success: onSuccess,
+      })
+    }
+
+    var resubmitWithAjax = function(onSuccessfulRender) {
+      if(!!settings.containerElement) {
+        requestHtmlFromServer(
+          $(this).attr('action'),
+          $(this).serialize(),
+          function(data) {
+            $(settings.containerElement).html(data)
+            
+            $('.dashdo-plotly-select .js-plotly-plot').each(function() {
+              var graph = $(this).get(0)
+              var axis = (graph.data[0].orientation === 'h') ? 'y' : 'x'
+
+              var values = $(this).siblings('input[name]').map(function() {  // name must be specified!
+                return this.value
+              }).get()
               
-              $('.dashdo-plotly-select .js-plotly-plot').each(function() {
-                var graph = $(this).get(0)
-                var axis = (graph.data[0].orientation === 'h') ? 'y' : 'x'
+              var restyle = function() {
+                if (values.length === 0) {
+                  // making all graph selected
+                  // TODO: settings.colorSelected - barplots only. ?: maybe add alpha to deselect?
+                  Plotly.restyle(graph, { 'marker.color': settings.colorSelected })
+                } else {
+                  var os = graph.data[0][axis].map(function(p) {  // example: graph.data[0]['y']
+                    return (values.indexOf(p) !== -1) ? // p `elem` values == True
+                      settings.colorSelected : 
+                      settings.colorUnSelected
+                  })
+                  Plotly.restyle(graph, {'marker.color' : [os]}, [0])
+                }
+              }
+              restyle()
 
-                var values = $(this).siblings('input[name]').map(function() {  // name must be specified!
-                  return this.value
-                }).get()
-                
-                var restyle = function() {
-                  if (values.length === 0) {
-                    // making all graph selected
-                    console.log('all are selected! ^))')
-                    Plotly.restyle(graph, { 'marker.color': settings.colorSelected })
+              var currentMultipleFieldName = $(this).siblings(settings.multiselectNamesSelector).val()
+              var isMultiple = !!currentMultipleFieldName
+
+              $(this).get(0).on('plotly_click', function(data) {
+                var selectedValueFromPlot = data.points[0][axis]
+
+                if(!isMultiple) {
+                  var input = $(this).siblings('input[name]').first()
+                  if (input.attr('value') == selectedValueFromPlot) { // if selected
+                    input.attr('value', '') // then deselect
                   } else {
-                    var os = graph.data[0][axis].map(function(p) {  // example: graph.data[0]['y']
-                      return (values.indexOf(p) !== -1) ? // p `elem` values == True
-                        settings.colorSelected : 
-                        settings.colorUnSelected
-                    })
-                    Plotly.restyle(graph, {'marker.color' : [os]}, [0])
+                    input.attr('value', selectedValueFromPlot)  // if not selected, then select
+                  }
+                } else {
+                  var currentInputs = $(this).siblings('input[name="' + currentMultipleFieldName + '"][value="' + selectedValueFromPlot + '"]')
+                  
+                  if (currentInputs.length > 0) {
+                    $(currentInputs).remove()
+                  } else {
+                    $(this).after('<input type="hidden" name="' + currentMultipleFieldName + '" value="' + selectedValueFromPlot + '">')
                   }
                 }
-                restyle()
 
-                var currentMultipleFieldName = $(this).siblings(settings.multiselectNamesSelector).val()
-                var isMultiple = !!currentMultipleFieldName
+                properReSubmit()
+              }.bind(this))
+            })
 
-                $(this).get(0).on('plotly_click', function(data) {
-                  var selectedValueFromPlot = data.points[0][axis]
+            // if switched & rendered successfully, renew periodic submit loop
+            clearInterval(submitTimer)
+            periodicSubmitLoop()
+          }.bind(this)
+        )
+      }
+    }.bind(this)
 
-                  if(!isMultiple) {
-                    var input = $(this).siblings('input[name]').first()
-                    if (input.attr('value') == selectedValueFromPlot) { // if selected
-                      input.attr('value', '') // then deselect
-                    } else {
-                      input.attr('value', selectedValueFromPlot)  // if not selected, then select
-                    }
-                  } else {
-                    var currentInputs = $(this).siblings('input[name="' + currentMultipleFieldName + '"][value="' + selectedValueFromPlot + '"]')
-                    
-                    if (currentInputs.length > 0) {
-                      $(currentInputs).remove()
-                    } else {
-                      $(this).after('<input type="hidden" name="' + currentMultipleFieldName + '" value="' + selectedValueFromPlot + '">')
-                    }
-                  }
+    var properReSubmit = (settings.ajax) ?
+          resubmitWithAjax :
+          resubmitNatively
 
-                  properReSubmit()
-                }.bind(this))
-              })
-
-              // if switched & rendered successfully, renew periodic submit loop
-              clearInterval(submitTimer)
-              periodicSubmitLoop()
-            }.bind(this)
-          )
+    var uuid = null
+    var uuidLoop = function() {
+      $.get(settings.uuidUrl).done(function(data) {
+        if(uuid && uuid != data) {
+          properReSubmit()
         }
-      }.bind(this)
+        uuid = data
+      }).always(function() {
+        setTimeout(uuidLoop, settings.uuidInterval)
+      })
+    }
+    uuidLoop()
 
-      var properReSubmit = (settings.ajax) ?
-            resubmitWithAjax :
-            resubmitNatively
+    var submitTimer = null
+    var periodicSubmitLoop = function() {
+      var currentPeriodicSubmitValue = parseInt($(this).find(settings.periodicSubmitSelector).val())
+      if(!!currentPeriodicSubmitValue) {
+        properReSubmit()
+        submitTimer = setTimeout(periodicSubmitLoop.bind(this), currentPeriodicSubmitValue)
+      }
+    }.bind(this)
+    periodicSubmitLoop()
 
-      var uuid = null
-      var uuidLoop = function() {
-        $.get(settings.uuidUrl).done(function(data) {
-          if(uuid && uuid != data) {
-            properReSubmit()
-          }
-          uuid = data
-        }).always(function() {
-          setTimeout(uuidLoop, settings.uuidInterval)
+    // cosmetics
+    var refreshTitle = function(endpoint) {
+      if(!!settings.dashdoTitleSelector) {
+        var title = $(settings.switcherElements)
+        .filter('[' + settings.switcherAttr + '="' + endpoint + '"]')
+        .text()
+
+        if(!!title) {
+          $(settings.dashdoTitleSelector).text(title)
+        }
+      }
+    }
+
+    var switchDashdo = function(endpoint) {
+      $(this).attr('action', endpoint)  // set action of the form to the endpoint
+      refreshTitle(endpoint)
+      resubmitWithAjax()
+    }.bind(this)
+
+    if(settings.switcherElements !== null) {
+      var firstEndpoint = 
+        $(settings.switcherElements)
+          .first()
+          .attr(settings.switcherAttr)
+
+      if(firstEndpoint) {
+        switchDashdo(firstEndpoint)
+
+        $(settings.switcherElements).on(settings.switcherEvent, function(e) {
+          e.preventDefault()
+          switchDashdo($(e.target).attr(settings.switcherAttr))
         })
       }
-      uuidLoop()
-
-      var submitTimer = null
-      var periodicSubmitLoop = function() {
-        var currentPeriodicSubmitValue = parseInt($(this).find(settings.periodicSubmitSelector).val())
-        if(!!currentPeriodicSubmitValue) {
-          properReSubmit()
-          submitTimer = setTimeout(periodicSubmitLoop.bind(this), currentPeriodicSubmitValue)
-        }
-      }.bind(this)
-      periodicSubmitLoop()
-
-      // cosmetics
-      var refreshTitle = function(endpoint) {
-        if(!!settings.dashdoTitleSelector) {
-          var title = $(settings.switcherElements)
-          .filter('[' + settings.switcherAttr + '="' + endpoint + '"]')
-          .text()
-
-          if(!!title) {
-            $(settings.dashdoTitleSelector).text(title)
-          }
-        }
-      }
-
-      var switchDashdo = function(endpoint) {
-        $(this).attr('action', endpoint)  // set action of the form to the endpoint
-        refreshTitle(endpoint)
-        resubmitWithAjax()
-      }.bind(this)
-
-      if(settings.switcherElements !== null) {
-        var firstEndpoint = 
-          $(settings.switcherElements)
-            .first()
-            .attr(settings.switcherAttr)
-
-        if(firstEndpoint) {
-          switchDashdo(firstEndpoint)
-
-          $(settings.switcherElements).on(settings.switcherEvent, function(e) {
-            e.preventDefault()
-            switchDashdo($(e.target).attr(settings.switcherAttr))
-          })
-        }
-      }
-
-      return this // returning the dashdo
     }
- 
+
+    return this // returning the dashdo
+  }
+
 }( jQuery ))

--- a/dashdo/public/js/dashdo.js
+++ b/dashdo/public/js/dashdo.js
@@ -40,6 +40,36 @@
       multiselectNamesSelector: '.dashdo-plotly-multi-select-names',
     }, options)
 
+    var AbstractPlotRenderer = function() {}
+
+    AbstractPlotRenderer.prototype = {
+      pickValues: function() {
+        // should return list
+        // TODO: $(this).siblings('input[name]').map(function() { return this.value }).get()
+        throw new TypeError("Method not implemented")
+      },
+
+      restyleAll: function() {
+        throw new TypeError("Method not implemented")
+      },
+
+      restyleCurrent: function() {
+        throw new TypeError("Method not implemented")
+      },
+
+      isEmpty: function() {
+        return this.pickValues().length === 0
+      },
+
+      restyle: function(graph) {
+        if(this.isEmpty) {
+          this.restyleAll()
+        } else {
+          this.restyleCurrent()
+        }
+      },
+    }
+
     var resubmitNatively = function() {
       $('input', this).prop('readonly', true)
       $(this).submit()
@@ -107,21 +137,16 @@
               $(this).get(0).on('plotly_click', function(data) {
                 var selectedValueFromPlot = data.points[0][axis]
 
-                if(!isMultiple) {
-                  var input = $(this).siblings('input[name]').first()
-                  if (input.attr('value') == selectedValueFromPlot) { // if selected
-                    input.attr('value', '') // then deselect
-                  } else {
-                    input.attr('value', selectedValueFromPlot)  // if not selected, then select
-                  }
+                var inputSelector = 'input[name="' + currentMultipleFieldName + '"]' + 
+                  (isMultiple) ? // if isMultiple, then look for input with exact value
+                  '[value="' + selectedValueFromPlot + '"]' : 
+                  ''
+
+                var currentInputs = $(this).siblings(inputSelector)
+                if (currentInputs.length > 0) {
+                  $(currentInputs).remove()
                 } else {
-                  var currentInputs = $(this).siblings('input[name="' + currentMultipleFieldName + '"][value="' + selectedValueFromPlot + '"]')
-                  
-                  if (currentInputs.length > 0) {
-                    $(currentInputs).remove()
-                  } else {
-                    $(this).after('<input type="hidden" name="' + currentMultipleFieldName + '" value="' + selectedValueFromPlot + '">')
-                  }
+                  $(this).after('<input type="hidden" name="' + currentMultipleFieldName + '" value="' + selectedValueFromPlot + '">')
                 }
 
                 properReSubmit()

--- a/dashdo/src/Dashdo/Elements.hs
+++ b/dashdo/src/Dashdo/Elements.hs
@@ -111,12 +111,17 @@ checkbox text vTrue vFalse f = do
   -- if checkbox doesn't supply a value we get this one instead
   input_ [type_ "hidden", fieldName n, value_ "false"]
 
+resetLink :: SHtml a ()
+resetLink = do
+  a_ [href_ "#", class_"dashdo-resetlink"] "reset"
+
 plotlySelect :: Plotly -> Lens' a Text -> SHtml a ()
 plotlySelect plot f = do
   (val, n) <- freshAndValue
   putFormField (n, lensSetter f)
   div_ [class_ "dashdo-plotly-select"] $ do
     toHtml plot
+    resetLink
     input_ [type_ "hidden", fieldName n, value_ (val ^. f)]
 
 plotlySelectMultiple :: Plotly -> Lens' a [Text] -> SHtml a ()
@@ -125,6 +130,7 @@ plotlySelectMultiple plot f = do
   putFormField (n, lensPusher f)
   div_ [class_ "dashdo-plotly-select"] $ do
     toHtml plot
+    resetLink
     input_ [type_ "hidden", class_ "dashdo-plotly-multi-select-names", value_ $ mkFieldNameMultiple n]
     forM_ (val ^. f) $ \(v) ->
       input_ [type_ "hidden", fieldNameMultiple n, value_ v]

--- a/plotlyhs/src/Graphics/Plotly/Base.hs
+++ b/plotlyhs/src/Graphics/Plotly/Base.hs
@@ -95,9 +95,16 @@ instance ToJSON a => ToJSON (ListOrElem a) where
   toJSON (List xs) = toJSON xs
   toJSON (All x) = toJSON x
 
+data Sizemode = Diameter | Area deriving (Show, Eq)
+
+instance ToJSON Sizemode where
+  toJSON = toJSON . map toLower . show
+
 -- | Marker specification
 data Marker = Marker
   { _size :: Maybe (ListOrElem Value)
+  , _sizeref :: Maybe Value
+  , _sizeMode :: Maybe Sizemode
   , _markercolor :: Maybe (ListOrElem Value)
   , _markercolors :: Maybe (ListOrElem Value) -- for pie charts
   , _symbol :: Maybe Symbol
@@ -111,7 +118,7 @@ instance ToJSON Marker where
 
 -- | default marker specification
 defMarker :: Marker
-defMarker  = Marker Nothing Nothing Nothing Nothing Nothing
+defMarker  = Marker Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 
 -- | Dash type specification

--- a/plotlyhs/src/Graphics/Plotly/Base.hs
+++ b/plotlyhs/src/Graphics/Plotly/Base.hs
@@ -227,9 +227,15 @@ instance ToJSON Trace where
   toJSON = genericToJSON jsonOptions {fieldLabelModifier = renamer}
     where renamer = dropInitial "trace" . unLens
 
+data AxisType = Log | Date | Category deriving Show
+
+instance ToJSON AxisType where
+  toJSON = toJSON . map toLower . show
+
 -- |Options for axes
 data Axis = Axis
   { _range :: Maybe (Double,Double)
+  , _axistype :: Maybe AxisType
   , _axistitle :: Maybe Text
   , _showgrid :: Maybe Bool
   , _zeroline :: Maybe Bool
@@ -244,7 +250,7 @@ instance ToJSON Axis where
   toJSON = genericToJSON jsonOptions {fieldLabelModifier = dropInitial "axis" . unLens}
 
 defAxis :: Axis
-defAxis = Axis Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+defAxis = Axis Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 -- * Layouts
 

--- a/plotlyhs/src/Graphics/Plotly/Base.hs
+++ b/plotlyhs/src/Graphics/Plotly/Base.hs
@@ -60,7 +60,7 @@ instance {-# OVERLAPS #-} ToJSON [Mode] where
   toJSON = toJSON . intercalate "+" . map (map toLower . dropInitial "Mode" . show)
 
 -- | What kind of plot type are we building - scatter (inluding line plots) or bars?
-data TraceType = Scatter | Scatter3D | Bar | Mesh3D deriving Show
+data TraceType = Scatter | Scatter3D | Bar | Mesh3D | Pie deriving Show
 
 instance ToJSON TraceType where
   toJSON = toJSON . map toLower . show
@@ -99,6 +99,7 @@ instance ToJSON a => ToJSON (ListOrElem a) where
 data Marker = Marker
   { _size :: Maybe (ListOrElem Value)
   , _markercolor :: Maybe (ListOrElem Value)
+  , _markercolors :: Maybe (ListOrElem Value) -- for pie charts
   , _symbol :: Maybe Symbol
   , _opacity :: Maybe Double
   } deriving (Generic, Eq)
@@ -110,7 +111,7 @@ instance ToJSON Marker where
 
 -- | default marker specification
 defMarker :: Marker
-defMarker  = Marker Nothing Nothing Nothing Nothing
+defMarker  = Marker Nothing Nothing Nothing Nothing Nothing
 
 
 -- | Dash type specification
@@ -176,6 +177,9 @@ data Trace = Trace
   { _x :: Maybe [Value] -- ^ x values, as numbers
   , _y :: Maybe [Value] -- ^ y values, as numbers
   , _z :: Maybe [Value] -- ^ z values, as numbers
+  , _values :: Maybe [Value] -- values for pie chart
+  , _labels :: Maybe [Text] -- labels for pie chart
+  , _hole :: Maybe Value -- pie chart hole property
   , _mode :: Maybe [Mode] -- ^ select one or two modes.
   , _name :: Maybe Text -- ^ name of this trace, for legend
   , _text :: Maybe [Text]
@@ -204,7 +208,7 @@ data Trace = Trace
 makeLenses ''Trace
 
 mkTrace :: TraceType -> Trace
-mkTrace tt = Trace Nothing Nothing Nothing Nothing Nothing Nothing Nothing tt Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+mkTrace tt = Trace Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing tt Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 -- |an empty scatter plot
 scatter :: Trace
@@ -222,6 +226,9 @@ bars = mkTrace Bar
 mesh3d :: Trace
 mesh3d = mkTrace Mesh3D
 
+-- | an empty pie chart
+pie :: Trace
+pie = mkTrace Pie
 
 instance ToJSON Trace where
   toJSON = genericToJSON jsonOptions {fieldLabelModifier = renamer}

--- a/plotlyhs/src/Graphics/Plotly/Base.hs
+++ b/plotlyhs/src/Graphics/Plotly/Base.hs
@@ -199,6 +199,7 @@ data Trace = Trace
   , _visible :: Maybe Value
   , _traceshowlegend :: Maybe Bool
   , _legendgroup :: Maybe Text
+  , _customdata :: Maybe [Value]
   , _hoverinfo :: Maybe HoverInfo
   , _hovertext :: Maybe (ListOrElem Text)
   , _hoveron :: Maybe [HoverOn]
@@ -215,7 +216,7 @@ data Trace = Trace
 makeLenses ''Trace
 
 mkTrace :: TraceType -> Trace
-mkTrace tt = Trace Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing tt Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+mkTrace tt = Trace Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing tt Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 -- |an empty scatter plot
 scatter :: Trace

--- a/plotlyhs/src/Graphics/Plotly/Simple.hs
+++ b/plotlyhs/src/Graphics/Plotly/Simple.hs
@@ -28,8 +28,14 @@ linePlot xys    = scatter & x ?~ map (toJSON .fst) xys
 -- |Generate a horizontal bar chart from pairs of text and value.
 hbarChart :: [(Text, Double)] -> Trace
 hbarChart tvs = bars & y ?~ map (toJSON . fst) tvs
-                     & x ?~ map (toJSON .snd) tvs
+                     & x ?~ map (toJSON . snd) tvs
                      & orientation ?~ Horizontal
+
+-- |Generate a horizontal bar chart from pairs of text and value.
+vbarChart :: [(Text, Double)] -> Trace
+vbarChart tvs = bars & x ?~ map (toJSON . fst) tvs
+                     & y ?~ map (toJSON . snd) tvs
+                     & orientation ?~ Vertical
 
 -- |Generate a fan plot with a given width in standard deviations and
 --  (x,(y,sd)) data


### PR DESCRIPTION
New controls available for (cross)filtering:
 - Doghunt charts (also known as piecharts)
 - Scatterplots

New axis type:
 - Log

New features available from haskell. User can now add:
 - `_customdata` (for doghunt charts and scatterplots), `_hole`, `_labels`, `_values` (for dohgunt charts) to `Trace`
 - `_axistype` (of type `AxisType`)
 - reset links

See an example of working crossfilter: dashdo-examples/src/GapminderScatterplot.hs

Fixed bugs:
 - In the previous version `restyle` event did not happen on 'native' submit. Fixed.