### PR TITLE
Fix symlink creation in Nginx

### DIFF
--- a/dampf/lib/Dampf/Nginx.hs
+++ b/dampf/lib/Dampf/Nginx.hs
@@ -30,7 +30,7 @@ deployDomains = do
 
             T.writeFile ("/etc/nginx/sites-available" </> strName) fl
             removePathForcibly ("/etc/nginx/sites-enabled" </> strName)
-            createSymbolicLink ("/etc/nginx-sites-available" </> strName)
+            createSymbolicLink ("/etc/nginx/sites-available" </> strName)
                 ("/etc/nginx/sites-enabled" </> strName)
 
             void $ system "service nginx reload"


### PR DESCRIPTION
The symbolic link from sites-available to sites-enabled was not being
created correctly, as the source path had a dash instead of a path
separator. This issue has been fixed.