### PR TITLE
Fixed examples in dashdo-refactor2

### DIFF
--- a/dashdo-examples/dashdo-examples.cabal
+++ b/dashdo-examples/dashdo-examples.cabal
@@ -75,3 +75,4 @@ executable gapminder-dashdo
                      , dashdo
                      , microlens-platform
                      , lucid-extras
+                     , mtl

--- a/dashdo-examples/dashdo-examples.cabal
+++ b/dashdo-examples/dashdo-examples.cabal
@@ -60,6 +60,7 @@ executable statview-dashdo
                      , statgrab
                      , lucid-extras
                      , unix
+                     , mtl
 
 executable gapminder-dashdo
   main-is: GapminderScatterplot.hs

--- a/dashdo-examples/dashdo-examples.cabal
+++ b/dashdo-examples/dashdo-examples.cabal
@@ -26,6 +26,7 @@ executable test-dashdo
                      , text
                      , dashdo
                      , microlens-platform
+                     , mtl
 
 executable iris-kmeans-dashdo
   main-is: IrisKMeans.hs

--- a/dashdo-examples/src/IrisKMeans.hs
+++ b/dashdo-examples/src/IrisKMeans.hs
@@ -7,6 +7,7 @@ import Dashdo.Types
 import Dashdo.Serve
 import Dashdo.Elements
 import Control.Monad
+import Control.Monad.State.Strict
 import Lucid
 import Lucid.Bootstrap3
 import Lucid.Bootstrap
@@ -41,9 +42,11 @@ irisData
     ~~ [sepalLength, sepalWidth, petalLength, petalWidth])
     iris
 
-main = runDashdo $ pureDashdo ikm0 dashdo
+main = runDashdoIO $ Dashdo ikm0 dashdo
 
-dashdo ikm = wrap plotlyCDN $ do
+dashdo :: SHtml IO IKM ()
+dashdo = wrap plotlyCDN $ do
+    (_, ikm ,_) <- lift $ get
     let ctrs :: [VS.Vector Double]
         ctrs = model $ runIdentity $ runSupervisor (kmeans $ ikm ^. nclusters) Nothing irisData
 

--- a/dashdo-examples/src/TestDashdo.hs
+++ b/dashdo-examples/src/TestDashdo.hs
@@ -7,6 +7,7 @@ import Dashdo.Types
 import Dashdo.Serve
 import Dashdo.Elements
 import Control.Monad
+import Control.Monad.State.Strict
 import Lucid
 import Data.Monoid ((<>))
 import Data.Text (Text, unpack, pack)
@@ -26,14 +27,13 @@ data Example = Example
 
 makeLenses ''Example
 
+main = runDashdoIO theDashdo
 
-main = do
-  runDashdo theDashdo
+theDashdo = Dashdo initv (example iris)
 
-theDashdo = Dashdo initv (return . const ()) (example iris)
-
-example :: [Iris] -> Example -> () -> SHtml Example ()
-example irisd nm () = wrap plotlyCDN $ do
+example :: [Iris] -> SHtml IO Example ()
+example irisd = wrap plotlyCDN $ do
+  (_, nm, _)  <- lift $ get
   let ptitle = if _isMale nm then "Mr " else "Ms "
       trace :: Trace
       trace = points (aes & x .~ (nm ^. xaxis . tagVal)
@@ -53,7 +53,6 @@ axes = [tagOpt "sepal length" sepalLength,
         tagOpt "sepal width" sepalWidth,
         tagOpt "petal length" petalLength,
         tagOpt "petal width" petalWidth]
-
 
 initv = Example "Simon" True (snd $ axes!!0) (snd $ axes!!1)
 


### PR DESCRIPTION
All of the examples are working now:
- test-dashdo
- iris-kmeans-dashdo
- statview-dashdo
- gapminder-dashdo

Had to add `mtl` package to each one of them (to use `lift`)



