### PR TITLE
Partial update using (#>)

### DIFF
--- a/dashdo-examples/src/TestDashdo.hs
+++ b/dashdo-examples/src/TestDashdo.hs
@@ -37,12 +37,12 @@ test = do
   "The person is male: "
   if b then "yes" else "no"
 
-hello :: String -> SHtml IO Text ()
-hello title = do
+hello :: SHtml IO Text ()
+hello = do
   textInput id
   br_ []
   txt  <- getValue
-  "Hello, " <> (toHtml title) <> (toHtml txt) <> "!"
+  "Hello, " <> (toHtml txt) <> "!"
 
 example :: [Iris] -> SHtml IO Example ()
 example irisd = wrap plotlyCDN $ do
@@ -57,8 +57,7 @@ example irisd = wrap plotlyCDN $ do
   select [("Male", True),("Female", False)] isMale
   br_ []
 
-  let ptitle = if nm ^. isMale then "Mr " else "Ms "
-  pname #> hello ptitle
+  pname #> hello
   br_ []
   
   isMale #> test

--- a/dashdo-examples/src/TestDashdo.hs
+++ b/dashdo-examples/src/TestDashdo.hs
@@ -35,7 +35,7 @@ test :: SHtml IO Bool ()
 test = do
   b <- getValue
   "The person is male: "
-  if b then "true" else "false"
+  if b then "yes" else "no"
 
 hello :: String -> SHtml IO Text ()
 hello title = do

--- a/dashdo/public/js/dashdo.js
+++ b/dashdo/public/js/dashdo.js
@@ -20,17 +20,20 @@
     else return "#"+(0x100000000+(f[3]>-1&&t[3]>-1?r(((t[3]-f[3])*p+f[3])*255):t[3]>-1?r(t[3]*255):f[3]>-1?r(f[3]*255):255)*0x1000000+r((t[0]-f[0])*p+f[0])*0x10000+r((t[1]-f[1])*p+f[1])*0x100+r((t[2]-f[2])*p+f[2])).toString(16).slice(f[3]>-1||t[3]>-1?1:3);
   }
 
+  var idToSelectorOrNull = function(x) {
+    return (!!x) ? '#' + x : null;
+  }
+
   $.fn.dashdo = function(options) {
     var settings = $.extend({
       // These are the defaults.
-      ajax: false,
       uuidUrl: '/uuid',
       uuidInterval: 1000,
 
       colorSelected: '#1F77B4',
       colorUnSelected: '#A5C8E1',
       
-      containerElement: null,
+      containerSelector: idToSelectorOrNull($(this).attr('id')),
       switcherElements: null,
       switcherAttr: 'href',
       switcherEvent: 'click',
@@ -42,32 +45,15 @@
       resetLinkSelector: '.dashdo-resetlink',
     }, options)
 
-    var resubmitNatively = function() {
-      $('input', this).prop('readonly', true)
-      $(this).submit()
-    }.bind(this)
-
-    var properReSubmit = function() {
-      if(settings.ajax) { 
-        resubmitWithAjax()
-      } else {
-        resubmitNatively()
-      }
-    }
-
     $(this).on('change', ':input', function() {
       if (typeof(manual_submit) === 'undefined' || !manual_submit) {
         $(':input').prop('readonly', true)
-        properReSubmit()
+        resubmit()
       }
     })
 
     this.filter('form').on('submit', function(e) {
-      if(!settings.ajax) {
-        $('input', this).prop('readonly', true)
-        return // and then it actualy submits
-      }
-      e.preventDefault()  // no 'native' submitting on ajax versions
+      e.preventDefault()  // no 'native' submitting
     })
 
     var requestHtmlFromServer = function(url, data, onSuccess) {
@@ -80,7 +66,7 @@
     }
 
     var restyleAndSetClickHandlers = function() {
-      $('.dashdo-plotly-select .js-plotly-plot').each(function() {
+      $('.dashdo-plotly-select .js-plotly-plot').each(function() {  // TODO what if there is no graph?
         var graphData = this.data[0]
         var axis = (graphData.orientation === 'h') ? 'y' : 'x'
         var values = $(this).siblings('input[name]').map(function() {  // name must be specified!
@@ -133,7 +119,7 @@
           $(settings.resetLinkSelector).each(function() {
             $(this).on('click', function() {
               $(this).siblings('input[name]').remove()
-              properReSubmit()
+              resubmit()
             })
           })
         }
@@ -175,20 +161,31 @@
             }
           }
 
-          properReSubmit()
+          resubmit()
         }.bind(this))
       })
     }
     restyleAndSetClickHandlers()
 
-    var resubmitWithAjax = function(onSuccessfulRender) {
-      if(!!settings.containerElement) {
+    var resubmit = function() {
+      if(!!settings.containerSelector) {
         requestHtmlFromServer(
           $(this).attr('action'),
           $(this).serialize(),
           function(data) {
-            $(settings.containerElement).html(data)
-            
+            var incomingHTML = $.parseHTML(data, null, true)
+            // select the same container from incomingHTML
+            var incomingContainer = $(incomingHTML).children(settings.containerSelector)
+
+            // if there is such container, replace current container with its contents
+            if(incomingContainer.length > 0) {
+              $(settings.containerSelector).html($(incomingContainer).contents())
+            } else {
+              // if no container found, then place all the incomingHTML into the container
+              // useful for partial rendering of folder in rdashdo
+              $(settings.containerSelector).html(incomingHTML)
+            }
+
             restyleAndSetClickHandlers()
             // if switched & rendered successfully, renew periodic submit loop
             clearInterval(submitTimer)
@@ -202,7 +199,7 @@
     var uuidLoop = function() {
       $.get(settings.uuidUrl).done(function(data) {
         if(uuid && uuid != data) {
-          properReSubmit()
+          resubmit()
         }
         uuid = data
       }).always(function() {
@@ -215,7 +212,7 @@
     var periodicSubmitLoop = function() {
       var currentPeriodicSubmitValue = parseInt($(this).find(settings.periodicSubmitSelector).val())
       if(!!currentPeriodicSubmitValue) {
-        properReSubmit()
+        resubmit()
         submitTimer = setTimeout(periodicSubmitLoop.bind(this), currentPeriodicSubmitValue)
       }
     }.bind(this)
@@ -237,7 +234,7 @@
     var switchDashdo = function(endpoint) {
       $(this).attr('action', endpoint)  // set action of the form to the endpoint
       refreshTitle(endpoint)
-      resubmitWithAjax()
+      resubmit()
     }.bind(this)
 
     if(settings.switcherElements !== null) {

--- a/dashdo/public/js/runners/rdashdo.js
+++ b/dashdo/public/js/runners/rdashdo.js
@@ -1,8 +1,7 @@
 (function($) {
   $(document).ready(function() {
     $('#dashdo-form').dashdo({
-      ajax: true,
-      containerElement: $('#dashdo-main'),
+      containerSelector: '#dashdo-main',
       switcherElements: $('.dashdo-link'),
     })
   })

--- a/dashdo/src/Dashdo.hs
+++ b/dashdo/src/Dashdo.hs
@@ -7,9 +7,9 @@ import Dashdo.Types
 import Data.Monoid ((<>))
 
 
-dashdoGenOut :: Monad m => Dashdo m a -> a -> m (TL.Text, FormFields a)
-dashdoGenOut (Dashdo _ r) x = do
-  (formFs, htmlText) <- runSHtml x r
+dashdoGenOut :: Monad m => Dashdo m a -> a -> [(TL.Text, TL.Text)] -> m (TL.Text, FormFields a)
+dashdoGenOut (Dashdo _ r) x pars = do
+  (formFs, htmlText) <- runSHtml x r pars
   return (htmlText, formFs)
 
 parseForm :: a -> FormFields a -> [(TL.Text, TL.Text)] -> a

--- a/dashdo/src/Dashdo/Elements.hs
+++ b/dashdo/src/Dashdo/Elements.hs
@@ -154,7 +154,7 @@ g #> r = do
 
   -- we running r, but say: take n as the counter for form fields
   let stT = renderTextT r
-  (txt, (_, subG, subFs)) <- (lift . lift) $ runStateT stT (n, v ^. g, [])
+  (txt, (_, _, subFs)) <- (lift . lift) $ runStateT stT (n, v ^. g, [])
   
   toHtmlRaw txt
   

--- a/dashdo/src/Dashdo/Serve.hs
+++ b/dashdo/src/Dashdo/Serve.hs
@@ -23,10 +23,10 @@ type RunInIO m = forall a. m a -> IO a
 
 dashdoHandler :: Monad m => RunInIO m -> Dashdo m a -> IO ([Param] -> ActionM ())
 dashdoHandler r d = do
-  (_, ff) <- r $ dashdoGenOut d (initial d)
+  (_, ff) <- r $ dashdoGenOut d (initial d) []
   return $ \ps -> do
          let newval = parseForm (initial d) ff ps
-         (thisHtml, _) <- liftIO $ r $ dashdoGenOut d newval
+         (thisHtml, _) <- liftIO $ r $ dashdoGenOut d newval ps
          html thisHtml
 
 getRandomUUID :: IO Text
@@ -43,7 +43,7 @@ runDashdo = runDashdoPort 3000
 
 runDashdoPort :: Monad m => Int -> RunInIO m -> Dashdo m a -> IO ()
 runDashdoPort prt r d = do
-  (iniHtml, _) <- r $ dashdoGenOut d (initial d)
+  (iniHtml, _) <- r $ dashdoGenOut d (initial d) []
   h <- dashdoHandler r d
   serve prt iniHtml [("", "", h)]
 

--- a/dashdo/src/Dashdo/Types.hs
+++ b/dashdo/src/Dashdo/Types.hs
@@ -13,7 +13,7 @@ type FormField t = (Text, t -> Text -> t)
 type FormFields t = [FormField t]
 type FieldName = Text
 
-type SHtml m t a = HtmlT (StateT ([FieldName],t,FormFields t) m) a
+type SHtml m t a = HtmlT (StateT ([FieldName],t,[(TL.Text, TL.Text)],FormFields t) m) a
 
 data RDashdo m = forall t. RDashdo
   { rdFid    :: String
@@ -24,40 +24,40 @@ data Dashdo m t = Dashdo
   { initial :: t
   , render :: SHtml m t () }
 
-runSHtml :: Monad m => t -> SHtml m t () -> m (FormFields t, TL.Text)
-runSHtml val shtml = do
+runSHtml :: Monad m => t -> SHtml m t () -> [(TL.Text, TL.Text)] -> m (FormFields t, TL.Text)
+runSHtml val shtml pars = do
   let stT = renderTextT shtml
       iniFldNams = map (("f"<>) . pack . show) [(0::Int)..]
-  (t, (_, _, ffs)) <- runStateT stT (iniFldNams, val, [])
+  (t, (_, _, _, ffs)) <- runStateT stT (iniFldNams, val,pars, [])
   return (ffs, t)
 
 fresh :: Monad m => SHtml m a FieldName
 fresh = do
-  (n:ns, v, ffs) <- lift $ get
-  lift $ put (ns, v, ffs)
+  (n:ns, v, pars, ffs) <- lift $ get
+  lift $ put (ns, v, pars, ffs)
   return n
 
 freshAndValue :: Monad m => SHtml m a (a, FieldName)
 freshAndValue = do
-  (n:ns, v, ffs) <- lift $ get
-  lift $ put (ns, v, ffs)
+  (n:ns, v, pars, ffs) <- lift $ get
+  lift $ put (ns, v, pars, ffs)
   return (v, n)
 
 named :: Monad m => FieldName -> SHtml m t a -> SHtml m t a
 named nm mx = do
-  (ns, v, ffs) <- lift $ get
-  lift $ put (nm:ns, v, ffs)
+  (ns, v, pars, ffs) <- lift $ get
+  lift $ put (nm:ns, v, pars, ffs)
   mx
 
 getValue :: Monad m => SHtml m a a
 getValue = do
-  (n, v, ffs) <- lift $ get
+  (n, v, pars, ffs) <- lift $ get
   return v
 
 putFormField :: Monad m => FormField t -> SHtml m t ()
 putFormField ff = do
-  (n, v, ffs) <- lift $ get
-  lift $ put (n, v, ff:ffs)
+  (n, v, pars, ffs) <- lift $ get
+  lift $ put (n, v, pars, ff:ffs)
   return ()
 
 lensSetter :: ASetter' s a -> (s -> a -> s)


### PR DESCRIPTION
Using (#>) we can now skip rendering of large widgets on server.

## Changes
- added `Hashable b` (substate is to be hashable) constraint for `(#>)`
- request params saved to the state in `SHtml` monad
- ajax-only rendering
- JavaScript API. Optional parameter `containerSelector` changed to `containerSelector`. **It accepts text only, no $(elements).** And default is `ID` attribute of `this` - element passed to `$.dashdo` function.

## How partial rendering works

1. **Serverside**. Inside of (#>) we check if hash of subfield has been changed. If yes, then we render it again, else we render an empty `span` with class `.dashdo-cashed-not-changed`. 

2. **Clientside**. In JavaScript:
2.1. We load `HTML` from server and parse it
2.2. Server can give the whole page (like almost all examples do) or a piece of page (like Rdashdo does). So we try to find elements that match `containerSelector` (that's why it needs to be text, not an object). If it is found, we work with thils little piece of DOM, else - with all the big DOM.
2.3. We try to find elements with class `.dashdo-cashed-not-changed` and replace them with corresponding parts of DOM tree currently rendered in the browser.
2.4 Replace current container's contents with code prepared at the previous step.

PS: We still run monad calculations, even if state not changed. The problem is need to know exact number of form fields. It is impossible withour running the state. It will be solved in later requests.