### PR TITLE
dashdo-examples as Dashdo.Examples library

### DIFF
--- a/dashdo-examples/dashdo-examples.cabal
+++ b/dashdo-examples/dashdo-examples.cabal
@@ -13,66 +13,53 @@ build-type:          Simple
 category:            Statistics, Web
 Cabal-Version: 	     >= 1.10
 
+library
+  hs-source-dirs:   lib
+  exposed-modules:
+    Dashdo.Examples.GapminderScatterplot
+    Dashdo.Examples.IrisKMeans
+    Dashdo.Examples.StatView
+    Dashdo.Examples.TestDashdo
+  build-depends:
+      base >= 4 && <= 5
+    , plotlyhs
+    , datasets
+    , lucid
+    , lucid-extras
+    , aeson
+    , text
+    , dashdo
+    , microlens-platform
+    , fuml
+    , vector
+    , mtl
+    , statgrab
+    , unix
 
 executable test-dashdo
   main-is: TestDashdo.hs
   default-language:  Haskell2010
-  hs-source-dirs:    src
+  hs-source-dirs:    exe
   build-depends:       base >=4.6 && <5
-                     , plotlyhs
-                     , datasets
-                     , lucid
-                     , aeson
-                     , text
-                     , dashdo
-                     , microlens-platform
-                     , mtl
+                     , dashdo-examples
 
 executable iris-kmeans-dashdo
   main-is: IrisKMeans.hs
   default-language:  Haskell2010
-  hs-source-dirs:    src
+  hs-source-dirs:    exe
   build-depends:       base >=4.6 && <5
-                     , plotlyhs
-                     , datasets
-                     , lucid
-                     , aeson
-                     , text
-                     , dashdo
-                     , microlens-platform
-                     , fuml
-                     , vector
-                     , mtl
-                     , lucid-extras
+                     , dashdo-examples
 
 executable statview-dashdo
   main-is: StatView.hs
   default-language:  Haskell2010
-  hs-source-dirs:    src
+  hs-source-dirs:    exe
   build-depends:       base >=4.6 && <5
-                     , plotlyhs
-                     , datasets
-                     , lucid
-                     , aeson
-                     , text
-                     , dashdo
-                     , microlens-platform
-                     , statgrab
-                     , lucid-extras
-                     , unix
-                     , mtl
+                     , dashdo-examples
 
 executable gapminder-dashdo
   main-is: GapminderScatterplot.hs
   default-language:  Haskell2010
-  hs-source-dirs:    src
+  hs-source-dirs:    exe
   build-depends:       base >=4.6 && <5
-                     , plotlyhs
-                     , datasets
-                     , lucid
-                     , aeson
-                     , text
-                     , dashdo
-                     , microlens-platform
-                     , lucid-extras
-                     , mtl
+                     , dashdo-examples

--- a/dashdo-examples/exe/GapminderScatterplot.hs
+++ b/dashdo-examples/exe/GapminderScatterplot.hs
@@ -1,0 +1,5 @@
+module Main where
+
+import Dashdo.Examples.GapminderScatterplot
+
+main = gapMinderScatterPlot

--- a/dashdo-examples/exe/IrisKMeans.hs
+++ b/dashdo-examples/exe/IrisKMeans.hs
@@ -1,0 +1,5 @@
+module Main where
+
+import Dashdo.Examples.IrisKMeans
+
+main = irisKMeans

--- a/dashdo-examples/exe/StatView.hs
+++ b/dashdo-examples/exe/StatView.hs
@@ -1,0 +1,5 @@
+module Main where
+
+import Dashdo.Examples.StatView
+
+main = statView

--- a/dashdo-examples/exe/TestDashdo.hs
+++ b/dashdo-examples/exe/TestDashdo.hs
@@ -1,0 +1,5 @@
+module Main where
+
+import Dashdo.Examples.TestDashdo
+
+main = testDashdo

--- a/dashdo-examples/lib/Dashdo/Examples/GapminderScatterplot.hs
+++ b/dashdo-examples/lib/Dashdo/Examples/GapminderScatterplot.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings, ExistentialQuantification, ExtendedDefaultRules, FlexibleContexts, TemplateHaskell #-}
+module Dashdo.Examples.GapminderScatterplot where
 
 import Numeric.Datasets
 import Numeric.Datasets.Gapminder
@@ -175,6 +176,6 @@ gmRenderer gms =
       mkCol [(MD,12)] $ do
         countriesTable $ (countriesFilter . continentsFilter) yearFilteredGMs
 
-main = do
+gapMinderScatterPlot = do
   gms <- getDataset gapminder
   runDashdoIO $ Dashdo gm0 (gmRenderer gms)

--- a/dashdo-examples/lib/Dashdo/Examples/IrisKMeans.hs
+++ b/dashdo-examples/lib/Dashdo/Examples/IrisKMeans.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings, ExistentialQuantification, ExtendedDefaultRules, FlexibleContexts, TemplateHaskell #-}
+module Dashdo.Examples.IrisKMeans where
 
 import Numeric.Datasets.Iris
 
@@ -42,7 +43,7 @@ irisData
     ~~ [sepalLength, sepalWidth, petalLength, petalWidth])
     iris
 
-main = runDashdoIO $ Dashdo ikm0 dashdo
+irisKMeans = runDashdoIO $ Dashdo ikm0 dashdo
 
 dashdo :: SHtml IO IKM ()
 dashdo = wrap plotlyCDN $ do

--- a/dashdo-examples/lib/Dashdo/Examples/StatView.hs
+++ b/dashdo-examples/lib/Dashdo/Examples/StatView.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings, ExtendedDefaultRules, FlexibleContexts, TemplateHaskell #-}
+module Dashdo.Examples.StatView where
 
 import System.Statgrab
 
@@ -124,7 +125,7 @@ process = do
 
 -- end of Processes dashdo
 
-main = do
+statView = do
   stats <- newMVar ([] :: [SysStats])
   forkIO (statGrab stats)
   let dashdos = [ RDashdo "load" "System Load" $ loadDashdo stats

--- a/dashdo-examples/lib/Dashdo/Examples/TestDashdo.hs
+++ b/dashdo-examples/lib/Dashdo/Examples/TestDashdo.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings, ExistentialQuantification, ExtendedDefaultRules, FlexibleContexts, TemplateHaskell #-}
+module Dashdo.Examples.TestDashdo where
 
 import Numeric.Datasets.Iris
 
@@ -27,9 +28,7 @@ data Example = Example
 
 makeLenses ''Example
 
-main = runDashdoIO theDashdo
-
-theDashdo = Dashdo initv (example iris)
+testDashdo = runDashdoIO $ Dashdo initv (example iris)
 
 test :: SHtml IO Bool ()
 test = do

--- a/dashdo-examples/lib/Dashdo/Examples/TestDashdo.hs
+++ b/dashdo-examples/lib/Dashdo/Examples/TestDashdo.hs
@@ -21,6 +21,7 @@ import Graphics.Plotly.Histogram (histogram)
 
 data Example = Example
  { _pname :: Text
+ , _pfoo :: Text
  , _isMale :: Bool
  , _xaxis :: Tag (Iris -> Double)
  , _yaxis :: Tag (Iris -> Double)
@@ -56,7 +57,14 @@ example irisd = wrap plotlyCDN $ do
   select [("Male", True),("Female", False)] isMale
   br_ []
 
+  h3_ "pname"
+
   pname #> hello
+  br_ []
+
+  h3_ "pfoo"
+
+  pfoo #> hello
   br_ []
   
   isMale #> test
@@ -71,7 +79,7 @@ axes = [tagOpt "sepal length" sepalLength,
         tagOpt "petal length" petalLength,
         tagOpt "petal width" petalWidth]
 
-initv = Example "Simon" True (snd $ axes!!0) (snd $ axes!!1)
+initv = Example "Simon" "bar" True (snd $ axes!!0) (snd $ axes!!1)
 
 {-hbarData :: [(Text, Double)]
 hbarData = [("Simon", 14.5), ("Joe", 18.9), ("Dorothy", 16.2)]


### PR DESCRIPTION
- `dashdo-examples` now contains `Dashdo.Examples` library
- `(#>)` is lazier now: it does not run the calculation of `Shtml` if HTML form has not been changed