### PR TITLE
Fix multiple lensing

### DIFF
--- a/dashdo-examples/lib/Dashdo/Examples/TestDashdo.hs
+++ b/dashdo-examples/lib/Dashdo/Examples/TestDashdo.hs
@@ -21,7 +21,6 @@ import Graphics.Plotly.Histogram (histogram)
 
 data Example = Example
  { _pname :: Text
- , _pfoo :: Text
  , _isMale :: Bool
  , _xaxis :: Tag (Iris -> Double)
  , _yaxis :: Tag (Iris -> Double)
@@ -57,14 +56,20 @@ example irisd = wrap plotlyCDN $ do
   select [("Male", True),("Female", False)] isMale
   br_ []
 
-  h3_ "pname"
-
-  pname #> hello
+  "Name input #1:"
+  textInput pname
   br_ []
 
-  h3_ "pfoo"
+  "Name input #2:"
+  textInput pname
+  br_ []
 
-  pfoo #> hello
+  "Name input #3:"
+  textInput pname
+  br_ []
+
+  "Greetings using (#>):"
+  pname #> hello
   br_ []
   
   isMale #> test
@@ -79,7 +84,7 @@ axes = [tagOpt "sepal length" sepalLength,
         tagOpt "petal length" petalLength,
         tagOpt "petal width" petalWidth]
 
-initv = Example "Simon" "bar" True (snd $ axes!!0) (snd $ axes!!1)
+initv = Example "Simon" True (snd $ axes!!0) (snd $ axes!!1)
 
 {-hbarData :: [(Text, Double)]
 hbarData = [("Simon", 14.5), ("Joe", 18.9), ("Dorothy", 16.2)]

--- a/dashdo/src/Dashdo.hs
+++ b/dashdo/src/Dashdo.hs
@@ -3,6 +3,7 @@
 module Dashdo where
 
 import qualified Data.Text.Lazy as TL
+import Data.List
 import Dashdo.Types
 import Data.Monoid ((<>))
 
@@ -13,12 +14,29 @@ dashdoGenOut (Dashdo _ r) x pars = do
   return (htmlText, formFs)
 
 parseForm :: a -> FormFields a -> [(TL.Text, TL.Text)] -> a
-parseForm x [] _ = x
-parseForm x ((fnm,f):nfs) pars =                  -- x=initial d (accumulator)
-  let fldName = TL.fromStrict fnm         -- fn
-      newx = case lookup fldName pars of        -- looking for fn in params [(TL.Text, TL.Text)]
-               Just lt -> f x (TL.toStrict lt)  -- apply function corresponding to `n` in list of FormFields - number-function pairs
-               Nothing -> case filter ((== fldName <> "[]") . fst) pars of -- if nothing found, try looking for fn[]
-                 [] -> x
-                 listParams -> foldl f x (map (TL.toStrict . snd) listParams)
-  in parseForm newx nfs pars
+parseForm x _ [] = x
+parseForm x ffs pars@((k,v):parsTail) =
+  let 
+    currentKeyIsList = "[]" `isSuffixOf` (TL.unpack k)
+
+    lookupKey =
+      if not currentKeyIsList
+        then TL.toStrict k
+        else TL.toStrict $ TL.dropEnd 2 k
+    
+    newx =
+      case lookup lookupKey ffs of  -- TODO: will not find fn[]
+        Just f  -> 
+          if not currentKeyIsList
+            then
+              f x $ TL.toStrict v
+            else
+              foldl f x (map (TL.toStrict . snd) $ filter ((==k) . fst) pars)
+        Nothing -> x
+
+    newparsTail =
+      if not currentKeyIsList
+        then parsTail
+        else filter (not . (==k) . fst) parsTail -- we have used that key, will not use anymore
+
+  in parseForm newx ffs newparsTail

--- a/dashdo/src/Dashdo/Types.hs
+++ b/dashdo/src/Dashdo/Types.hs
@@ -63,5 +63,5 @@ putFormField ff = do
 lensSetter :: ASetter' s a -> (s -> a -> s)
 lensSetter l x y = x & l .~ y
 
-lensPusher :: ASetter s t [a] [a] -> s -> a -> t
-lensPusher l x y = over l ((:) y) x
+lensPusher :: ASetter' s [a] -> (s -> a -> s)
+lensPusher l x y = x & l %~ ((:) y)


### PR DESCRIPTION
**Bug**: if multiple fields lens to one field, the first input's value will be taken, others will be discarded.

For example, if we got form like this:

```hs
"Name input #1:"
textInput pname
br_ []

"Name input #2:"
textInput pname
br_ []
```
(This example is available in `TestDashdo.hs`)

Input `#2` is correctly updated when we update input `#1`.

But input if we update input `#2`, the value of input `#1` overrides the new value.

**How it has been fixed (hacked)**:

- `parseForm` now runs through POST params looking for corresponding values in `FormFields a` - so order matters.
- newly-changed params go to the end of query string.