### PR TITLE
Add ability to create connection pool

### DIFF
--- a/postgresql-simple-expr/lib/Database/PostgreSQL/Simple/Connect.hs
+++ b/postgresql-simple-expr/lib/Database/PostgreSQL/Simple/Connect.hs
@@ -12,6 +12,8 @@ import Control.Exception
 import System.Environment
 
 import Database.PostgreSQL.Simple
+import Data.Pool
+import Data.Time.Clock
 
 data DatabaseConfig = DatabaseConfig
   { user                   :: String
@@ -19,6 +21,9 @@ data DatabaseConfig = DatabaseConfig
   , host                   :: String
   , port                   :: Integer
   , dbname                 :: String
+  , numstripes             :: Int
+  , keepOpenTime           :: NominalDiffTime
+  , resPerStripe           :: Int
   } deriving (Show, Eq, Generic)
 
 instance FromJSON DatabaseConfig
@@ -30,6 +35,10 @@ configFromEnv = DatabaseConfig
   <*> getEnv "PGHOST"
   <*> (read <$> getEnv "PGPORT")
   <*> getEnv "PGDATABASE"
+  <*> (maybe 2 read <$> (lookupEnv "PGPOOL_NUM_STRIPES"))
+  <*> (maybe (24*60*60) (fromIntegral . read) <$>
+       (lookupEnv "PGPOOL_KEEP_OPEN_TIME"))
+  <*> (maybe 20 read <$> (lookupEnv "PGPOOL_RES_PER_STRIPES"))
 
 
 createConn :: DatabaseConfig -> IO Connection
@@ -49,15 +58,11 @@ dbCfgToConnectInfo config = ConnectInfo
     }
 
 createConn' :: DatabaseConfig -> IO Connection
-createConn' = connect . dbCfgToConnectInfo 
+createConn' = connect . dbCfgToConnectInfo
 
-{-getPool :: DatabaseConfig -> PoolOrConn Connection
-getPool dbconfig=
- let poolCfg    = PoolCfg (fromMaybe 2 $ num_stripes dbconfig)
-                          (fromMaybe 20 $ res_per_stripe dbconfig)
-                          $ 24*60*60
-     pool       = PCConn $ ConnBuilder (createConn dbconfig) close poolCfg
- in pool -}
+createConnPool :: DatabaseConfig -> IO (Pool Connection)
+createConnPool cfg = createPool (createConn' cfg) close
+  (numstripes cfg) (keepOpenTime cfg) (resPerStripe cfg)
 
 readJSON :: FromJSON a => FilePath -> IO a
 readJSON path = do

--- a/postgresql-simple-expr/postgresql-simple-expr.cabal
+++ b/postgresql-simple-expr/postgresql-simple-expr.cabal
@@ -30,3 +30,5 @@ library
                      , bytestring
                      , text
                      , mtl
+                     , resource-pool
+                     , time


### PR DESCRIPTION
Three new optional env variables are available:
PGPOOL_NUM_STRIPES (if not present, default to 2)
PGPOOL_KEEP_OPEN_TIME (if not present, default to 24 hours)
PGPOOL_RES_PER_STRIPES (if not present, default to 20)