### PR TITLE
A FromRequest instance that provides access to the whole request

### DIFF
--- a/youido/lib/Youido/Types.hs
+++ b/youido/lib/Youido/Types.hs
@@ -330,6 +330,9 @@ newtype FormFields = FormFields [(TL.Text, TL.Text)]
 instance FromRequest FormFields where
   fromRequest (_,pars) = Just $ FormFields pars
 
+instance FromRequest a => FromRequest (a, Request) where
+  fromRequest (rq, pars) = (,) <$> fromRequest (rq, pars) <*> (Just rq)
+
 --------------------------------------------------------------------------
 ---                 FORM HANDLING
 --------------------------------------------------------------------------


### PR DESCRIPTION
This instance can be useful to provide handlers access to the entire request to access information such as HTTP headers.