### PR TITLE
Add function for running queries as transactions

### DIFF
--- a/postgresql-simple-expr/postgresql-simple-expr.cabal
+++ b/postgresql-simple-expr/postgresql-simple-expr.cabal
@@ -32,6 +32,7 @@ library
                      , mtl
                      , resource-pool
                      , time
+                     , safe-exceptions
 
 test-suite tests
   type:             exitcode-stdio-1.0


### PR DESCRIPTION
I have added an mtl-style 'withTransactionC' function since postgres-simple is restricted to IO only. The function rolls back if there is an exception mid-way through the transaction. I added the `safe-exceptions` package to achieve this.