### PR TITLE
Fix bug in dynamic deletion of youido subforms

### DIFF
--- a/youido/form-repeat.js
+++ b/youido/form-repeat.js
@@ -19,6 +19,13 @@ function youidoUpdatePaths($items, fieldName, fieldPath) {
   });
 }
 
+function youidoGetFieldPath(itemsDiv) {
+  var indices = $(itemsDiv).children("input[id$='.indices']")[0];
+  if (!!indices) {
+    return indices.id.replace(/\.indices$/, '');
+  } else return null;
+}
+
 function youidoUpdateIndices(fieldPath, newLength) {
   var newVal = '';
   for (var i=0; i < newLength; i++) {
@@ -38,7 +45,8 @@ function youidoUpdate($items, fieldName, fieldPath) {
   youidoUpdateIndices(fieldPath, $itemsNoDummy.length);
 }
 
-function youidoAddItem(itemsDiv, fieldName, fieldPath) {
+function youidoAddItem(itemsDiv, fieldName) {
+  var fieldPath = youidoGetFieldPath(itemsDiv);
   var dummyId = fieldPath + '.' + youidoDummyItem;
   var dummy = document.getElementById(dummyId);
   var newItem = dummy.cloneNode(true);
@@ -50,8 +58,9 @@ function youidoAddItem(itemsDiv, fieldName, fieldPath) {
   youidoUpdate($items, fieldName, fieldPath);
 }
 
-function youidoRemoveItem(item, fieldName, fieldPath) {
+function youidoRemoveItem(item, fieldName) {
   var itemsDiv = item.parentNode;
+  var fieldPath = youidoGetFieldPath(itemsDiv);
   itemsDiv.removeChild(item);
   youidoUpdate($(itemsDiv).children('div.' + youidoItemClass), fieldName, fieldPath);
 }

--- a/youido/lib/Youido/Types.hs
+++ b/youido/lib/Youido/Types.hs
@@ -512,10 +512,9 @@ instance FromForm a => FormField [a] where
   fromFormField = D.listOf fromForm
   renderField _ fieldName label view = do
     let fieldPath = D.absolutePath fieldName view
-        fieldPathT = D.fromPath fieldPath
         indicesPath = fieldPath ++ [D.indicesRef]
         indicesPathT = D.fromPath indicesPath
-        jsArgs = ["this.parentNode", jsStr fieldName, jsStr fieldPathT]
+        jsArgs = ["this.parentNode", jsStr fieldName]
         onclickDelete = jsCall "youidoRemoveItem" jsArgs <> "; return false;"
         onclickAdd = jsCall "youidoAddItem" jsArgs <> "; return false;"
 
@@ -535,7 +534,7 @@ instance FromForm a => FormField [a] where
         dummyView = D.makeListSubView fieldName (-1) view
         dummy = renderItem (Proxy :: Proxy a) onclickDelete dummyView
       with dummy [ style_ "display: none"
-                 , id_ (fieldPathT <> ".youido_dummy_item")]
+                 , id_ (D.fromPath fieldPath <> ".youido_dummy_item")]
 
       traverse_ (renderItem (Proxy :: Proxy a) onclickDelete) $
         D.listSubViews fieldName view


### PR DESCRIPTION
The field path cannot be set from haskell but needs to be discovered
from the javascript each time, in case parent forms are deleted and
the indices change.