### PR TITLE
ToURL class now has ToURLSegments instead of a toURL method

### DIFF
--- a/youido/lib/Youido/Dashdo.hs
+++ b/youido/lib/Youido/Dashdo.hs
@@ -61,9 +61,9 @@ instance Monad m => FromRequest m DashdoReq where
       Nothing -> unexpected "failure"
 
 instance ToURL DashdoReq where
-  toURL (InitialWith pars)
-    = "/with?"<>(intercalate "&" $ map (\(k,v)->k<>"="<>v) pars)
-  toURL _ = "/"
+  toURLSegments (InitialWith pars)
+    = ["with?"<>(intercalate "&" $ map (\(k,v)->k<>"="<>v) pars)]
+  toURLSegments _ = [""]
 
 
 dashdoHandler' :: forall s m t auth. (KnownSymbol s, MonadIO m, Show t)


### PR DESCRIPTION
toURL is now a polymorphic function that works on instances of ToURL.
This is done to make it easier to control where slashes appear in the URL.
--

Please let me know if I have omitted something.